### PR TITLE
[Feat] #9 - 검색 화면 구현

### DIFF
--- a/AppStoreClone/AppStoreClone/App/SceneDelegate.swift
+++ b/AppStoreClone/AppStoreClone/App/SceneDelegate.swift
@@ -20,9 +20,11 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         let service = ITunesService()
         let repository = DefaultSearchRepository(iTunesService: service)
-        let useCase = FetchSeasonSongUseCase(songRepository: repository)
+        let useCase = FetchSeasonSongUseCase(repository: repository)
         let viewModel = HomeViewModel(fetchSeasonSongUseCase: useCase)
-        window?.rootViewController = HomeViewController(viewModel: viewModel)
+        let homeViewController = HomeViewController(viewModel: viewModel)
+        let navigationController = UINavigationController(rootViewController: homeViewController)
+        window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
     }
 }

--- a/AppStoreClone/AppStoreClone/App/SceneDelegate.swift
+++ b/AppStoreClone/AppStoreClone/App/SceneDelegate.swift
@@ -19,7 +19,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
 
         let service = ITunesService()
-        let repository = DefaultSongRepository(iTunesService: service)
+        let repository = DefaultSearchRepository(iTunesService: service)
         let useCase = FetchSeasonSongUseCase(songRepository: repository)
         let viewModel = HomeViewModel(fetchSeasonSongUseCase: useCase)
         window?.rootViewController = HomeViewController(viewModel: viewModel)

--- a/AppStoreClone/AppStoreClone/Data/Mapper/ShowMapper.swift
+++ b/AppStoreClone/AppStoreClone/Data/Mapper/ShowMapper.swift
@@ -1,0 +1,30 @@
+//
+//  ShowMapper.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/14/25.
+//
+
+import Foundation
+
+struct ShowMapper {
+    static func map(_ dto: ShowDTO) -> Show? {
+        let kind: ShowKind = dto.kind == "podcast" ? .podcast : .movie
+        let title = dto.trackName
+        let artist = dto.artistName
+        let artworkURL = dto.artworkURL
+        let genre = dto.primaryGenreName
+
+        let isoFormatter = ISO8601DateFormatter()
+        guard let date = isoFormatter.date(from: dto.releaseDate) else { return nil }
+
+        return Show(
+            kind: kind,
+            title: title,
+            artist: artist,
+            artworkURL: artworkURL,
+            genre: genre,
+            releaseDate: date
+        )
+    }
+}

--- a/AppStoreClone/AppStoreClone/Data/Mapper/ShowMapper.swift
+++ b/AppStoreClone/AppStoreClone/Data/Mapper/ShowMapper.swift
@@ -12,7 +12,7 @@ struct ShowMapper {
         let kind: ShowKind = dto.kind == "podcast" ? .podcast : .movie
         let title = dto.trackName
         let artist = dto.artistName
-        let artworkURL = dto.artworkURL
+        let artworkImageURL = dto.artworkImageURL
         let genre = dto.primaryGenreName
 
         let isoFormatter = ISO8601DateFormatter()
@@ -22,7 +22,7 @@ struct ShowMapper {
             kind: kind,
             title: title,
             artist: artist,
-            artworkURL: artworkURL,
+            artworkImageURL: artworkImageURL,
             genre: genre,
             releaseDate: date
         )

--- a/AppStoreClone/AppStoreClone/Data/Model/SearchMediaType.swift
+++ b/AppStoreClone/AppStoreClone/Data/Model/SearchMediaType.swift
@@ -1,0 +1,27 @@
+//
+//  SearchType.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/14/25.
+//
+
+import Foundation
+
+enum SearchMediaType {
+    case music(Season)
+    case movie(String)
+    case podcast(String)
+
+    var query: String {
+        switch self {
+        case .music(let season):
+            let searchTerm = season.queryTerm
+            let limit = season.resultLimit
+            return "media=music&entity=song&genreId=51&term=\(searchTerm)&limit=\(limit)"
+        case .movie(let searchTerm):
+            return "media=movie&entity=movie&term=\(searchTerm)&limit=5"
+        case .podcast(let searchTerm):
+            return "media=podcast&entity=podcast&term=\(searchTerm)&limit=5"
+        }
+    }
+}

--- a/AppStoreClone/AppStoreClone/Data/Model/SearchResponse.swift
+++ b/AppStoreClone/AppStoreClone/Data/Model/SearchResponse.swift
@@ -1,0 +1,12 @@
+//
+//  SearchResponse.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/14/25.
+//
+
+import Foundation
+
+struct SearchResponse<T: Decodable>: Decodable {
+    let results: [T]
+}

--- a/AppStoreClone/AppStoreClone/Data/Model/ShowDTO.swift
+++ b/AppStoreClone/AppStoreClone/Data/Model/ShowDTO.swift
@@ -1,0 +1,26 @@
+//
+//  ShowDTO.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/13/25.
+//
+
+import Foundation
+
+struct ShowDTO: Decodable {
+    let kind: String
+    let trackName: String
+    let artistName: String
+    let artworkURL: String
+    let primaryGenreName: String
+    let releaseDate: String
+
+    enum CodingKeys: String, CodingKey {
+        case kind
+        case trackName
+        case artistName
+        case artworkURL = "artworkUrl30"
+        case primaryGenreName
+        case releaseDate
+    }
+}

--- a/AppStoreClone/AppStoreClone/Data/Model/ShowDTO.swift
+++ b/AppStoreClone/AppStoreClone/Data/Model/ShowDTO.swift
@@ -11,7 +11,7 @@ struct ShowDTO: Decodable {
     let kind: String
     let trackName: String
     let artistName: String
-    let artworkURL: String
+    let artworkImageURL: String
     let primaryGenreName: String
     let releaseDate: String
 
@@ -19,7 +19,7 @@ struct ShowDTO: Decodable {
         case kind
         case trackName
         case artistName
-        case artworkURL = "artworkUrl30"
+        case artworkImageURL = "artworkUrl30"
         case primaryGenreName
         case releaseDate
     }

--- a/AppStoreClone/AppStoreClone/Data/Model/ShowResponse+DTO.swift
+++ b/AppStoreClone/AppStoreClone/Data/Model/ShowResponse+DTO.swift
@@ -1,8 +1,0 @@
-//
-//  ShowResponse.swift
-//  AppStoreClone
-//
-//  Created by 곽다은 on 5/13/25.
-//
-
-import Foundation

--- a/AppStoreClone/AppStoreClone/Data/Model/ShowResponse+DTO.swift
+++ b/AppStoreClone/AppStoreClone/Data/Model/ShowResponse+DTO.swift
@@ -1,0 +1,8 @@
+//
+//  ShowResponse.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/13/25.
+//
+
+import Foundation

--- a/AppStoreClone/AppStoreClone/Data/Model/SongDTO.swift
+++ b/AppStoreClone/AppStoreClone/Data/Model/SongDTO.swift
@@ -1,15 +1,11 @@
 //
-//  SongResponse+DTO.swift
+//  SongDTO.swift
 //  AppStoreClone
 //
 //  Created by 곽다은 on 5/10/25.
 //
 
 import Foundation
-
-struct SongResponse: Decodable {
-    let results: [SongDTO]
-}
 
 struct SongDTO: Decodable {
     let trackName: String

--- a/AppStoreClone/AppStoreClone/Data/Network/ITunesService.swift
+++ b/AppStoreClone/AppStoreClone/Data/Network/ITunesService.swift
@@ -11,9 +11,8 @@ import RxSwift
 final class ITunesService {
     let baseURL = "https://itunes.apple.com/search?"
 
-    func fetchSongSearchResult(term: String, limit: Int) -> Single<[SongDTO]> {
-        let query = "media=music&entity=song&genreId=51&term=\(term)&limit=\(limit)"
-        let urlString = baseURL + query
+    func fetch<T: Decodable>(type: SearchMediaType) -> Single<[T]> {
+        let urlString = baseURL + type.query
 
         guard let url = URL(string: urlString) else {
             return Single.create { observer in
@@ -26,7 +25,7 @@ final class ITunesService {
             Task {
                 do {
                     let (data, _) = try await URLSession.shared.data(from: url)
-                    let decodedData = try JSONDecoder().decode(SongResponse.self, from: data)
+                    let decodedData = try JSONDecoder().decode(SearchResponse<T>.self, from: data)
                     observer(.success(decodedData.results))
                 } catch {
                     observer(.failure(error))

--- a/AppStoreClone/AppStoreClone/Data/Repository/DefaultSearchRepository.swift
+++ b/AppStoreClone/AppStoreClone/Data/Repository/DefaultSearchRepository.swift
@@ -30,5 +30,4 @@ final class DefaultSearchRepository: SearchRepository {
             (movies + podcasts).sorted { $0.releaseDate > $1.releaseDate }
         }
     }
-
 }

--- a/AppStoreClone/AppStoreClone/Data/Repository/DefaultSearchRepository.swift
+++ b/AppStoreClone/AppStoreClone/Data/Repository/DefaultSearchRepository.swift
@@ -8,7 +8,7 @@
 import Foundation
 import RxSwift
 
-final class DefaultSongRepository: SongRepository {
+final class DefaultSearchRepository: SearchRepository {
     let iTunesService: ITunesService
 
     init(iTunesService: ITunesService) {

--- a/AppStoreClone/AppStoreClone/Domain/Entity/Show.swift
+++ b/AppStoreClone/AppStoreClone/Domain/Entity/Show.swift
@@ -1,0 +1,17 @@
+//
+//  Show.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/13/25.
+//
+
+import Foundation
+
+struct Show {
+    let kind: ShowKind
+    let title: String
+    let collection: String
+    let artist: String
+    let artworkURL: String
+    let genre: String
+}

--- a/AppStoreClone/AppStoreClone/Domain/Entity/Show.swift
+++ b/AppStoreClone/AppStoreClone/Domain/Entity/Show.swift
@@ -10,8 +10,8 @@ import Foundation
 struct Show {
     let kind: ShowKind
     let title: String
-    let collection: String
     let artist: String
     let artworkURL: String
     let genre: String
+    let releaseDate: Date
 }

--- a/AppStoreClone/AppStoreClone/Domain/Entity/Show.swift
+++ b/AppStoreClone/AppStoreClone/Domain/Entity/Show.swift
@@ -7,11 +7,11 @@
 
 import Foundation
 
-struct Show {
+struct Show: Hashable {
     let kind: ShowKind
     let title: String
     let artist: String
-    let artworkURL: String
+    let artworkImageURL: String
     let genre: String
     let releaseDate: Date
 }

--- a/AppStoreClone/AppStoreClone/Domain/Entity/ShowKind.swift
+++ b/AppStoreClone/AppStoreClone/Domain/Entity/ShowKind.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum ShowKind {
+enum ShowKind: CaseIterable, Hashable {
     case movie
     case podcast
 }

--- a/AppStoreClone/AppStoreClone/Domain/Entity/ShowKind.swift
+++ b/AppStoreClone/AppStoreClone/Domain/Entity/ShowKind.swift
@@ -1,0 +1,13 @@
+//
+//  ShowKind.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/13/25.
+//
+
+import Foundation
+
+enum ShowKind {
+    case movie
+    case podcast
+}

--- a/AppStoreClone/AppStoreClone/Domain/Repository/SearchRepository.swift
+++ b/AppStoreClone/AppStoreClone/Domain/Repository/SearchRepository.swift
@@ -1,5 +1,5 @@
 //
-//  SongRepository.swift
+//  SearchRepository.swift
 //  AppStoreClone
 //
 //  Created by 곽다은 on 5/10/25.
@@ -8,6 +8,7 @@
 import Foundation
 import RxSwift
 
-protocol SongRepository {
+protocol SearchRepository {
     func searchSong(season: Season) -> Single<[Song]>
+    func searchShow(by searchQuery: String) -> Single<[Show]>
 }

--- a/AppStoreClone/AppStoreClone/Domain/Repository/SearchRepository.swift
+++ b/AppStoreClone/AppStoreClone/Domain/Repository/SearchRepository.swift
@@ -10,5 +10,5 @@ import RxSwift
 
 protocol SearchRepository {
     func searchSong(season: Season) -> Single<[Song]>
-    func searchShow(by searchQuery: String) -> Single<[Show]>
+    func searchShow(by term: String) -> Single<[Show]>
 }

--- a/AppStoreClone/AppStoreClone/Domain/UseCase/FetchSeasonSongUseCase.swift
+++ b/AppStoreClone/AppStoreClone/Domain/UseCase/FetchSeasonSongUseCase.swift
@@ -9,13 +9,13 @@ import Foundation
 import RxSwift
 
 final class FetchSeasonSongUseCase {
-    let songRepository: SongRepository
+    let repository: SearchRepository
 
-    init(songRepository: SongRepository) {
-        self.songRepository = songRepository
+    init(repository: SearchRepository) {
+        self.repository = repository
     }
 
     func execute(season: Season) -> Observable<[Song]> {
-        songRepository.searchSong(season: season).asObservable()
+        repository.searchSong(season: season).asObservable()
     }
 }

--- a/AppStoreClone/AppStoreClone/Domain/UseCase/FetchShowUseCase.swift
+++ b/AppStoreClone/AppStoreClone/Domain/UseCase/FetchShowUseCase.swift
@@ -1,0 +1,21 @@
+//
+//  FetchShowUseCase.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/13/25.
+//
+
+import Foundation
+import RxSwift
+
+final class FetchShowUseCase {
+    let repository: SearchRepository
+
+    init(repository: SearchRepository) {
+        self.repository = repository
+    }
+
+    func execute(searchQuery: String) -> Observable<[Show]> {
+        repository.searchShow(by: searchQuery).asObservable()
+    }
+}

--- a/AppStoreClone/AppStoreClone/Presentation/Home/View/HomeView.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/View/HomeView.swift
@@ -30,9 +30,9 @@ final class HomeView: UIView {
             forCellWithReuseIdentifier: MusicCompactCell.identifier
         )
         $0.register(
-            SectionHeader.self,
+            MusicHeader.self,
             forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
-            withReuseIdentifier: SectionHeader.identifier
+            withReuseIdentifier: MusicHeader.identifier
         )
     }
 
@@ -68,8 +68,7 @@ final class HomeView: UIView {
 
     private func setConstraints() {
         collectionView.snp.makeConstraints {
-            $0.top.equalTo(safeAreaLayoutGuide).inset(16)
-            $0.directionalHorizontalEdges.bottom.equalToSuperview()
+            $0.directionalEdges.equalToSuperview()
         }
     }
 
@@ -89,9 +88,9 @@ final class HomeView: UIView {
         dataSource?.supplementaryViewProvider = { collectionView, kind, indexPath in
             guard let header = collectionView.dequeueReusableSupplementaryView(
                 ofKind: kind,
-                withReuseIdentifier: SectionHeader.identifier,
+                withReuseIdentifier: MusicHeader.identifier,
                 for: indexPath
-            ) as? SectionHeader else { return nil }
+            ) as? MusicHeader else { return nil }
 
             let section = Season.allCases[indexPath.section]
             header.updateHeader(section.sectionTitle, section.sectionDescription)

--- a/AppStoreClone/AppStoreClone/Presentation/Home/View/HomeView.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/View/HomeView.swift
@@ -21,6 +21,7 @@ final class HomeView: UIView {
         frame: .zero,
         collectionViewLayout: createCollectionViewLayout()
     ).then {
+        $0.keyboardDismissMode = .onDrag
         $0.register(
             MusicBannerCell.self,
             forCellWithReuseIdentifier: MusicBannerCell.identifier

--- a/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicBannerCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicBannerCell.swift
@@ -88,10 +88,11 @@ final class MusicBannerCell: UICollectionViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
+        updateCell(with: nil, nil, nil)
         disposeBag = DisposeBag()
     }
 
-    func updateCell(with title: String, _ artist: String, _ artworkImageURL: String) {
+    func updateCell(with title: String?, _ artist: String?, _ artworkImageURL: String?) {
         Task {
             artworkImageView.image = await ImageLoader.shared.loadImage(from: artworkImageURL)
         }

--- a/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicBannerCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicBannerCell.swift
@@ -93,6 +93,7 @@ final class MusicBannerCell: UICollectionViewCell {
     }
 
     func updateCell(with title: String?, _ artist: String?, _ artworkImageURL: String?) {
+        guard let artworkImageURL else { return }
         Task {
             artworkImageView.image = await ImageLoader.shared.loadImage(from: artworkImageURL)
         }

--- a/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicCompactCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicCompactCell.swift
@@ -100,14 +100,15 @@ final class MusicCompactCell: UICollectionViewCell {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        updateCell(with: nil, nil, nil, nil)
         disposeBag = DisposeBag()
     }
 
     func updateCell(
-        with title: String,
-        _ artist: String,
-        _ artworkImageURL: String,
-        _ album: String
+        with title: String?,
+        _ artist: String?,
+        _ artworkImageURL: String?,
+        _ album: String?
     ) {
         Task {
             artworkImageView.image = await ImageLoader.shared.loadImage(from: artworkImageURL)

--- a/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicCompactCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicCompactCell.swift
@@ -110,6 +110,7 @@ final class MusicCompactCell: UICollectionViewCell {
         _ artworkImageURL: String?,
         _ album: String?
     ) {
+        guard let artworkImageURL else { return }
         Task {
             artworkImageView.image = await ImageLoader.shared.loadImage(from: artworkImageURL)
         }

--- a/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicHeader.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicHeader.swift
@@ -1,5 +1,5 @@
 //
-//  SectionHeader.swift
+//  MusicHeader.swift
 //  AppStoreClone
 //
 //  Created by 곽다은 on 5/11/25.
@@ -9,13 +9,13 @@ import UIKit
 import SnapKit
 import Then
 
-final class SectionHeader: UICollectionReusableView {
+final class MusicHeader: UICollectionReusableView {
 
     // MARK: - UIComponents
 
     private let titleLabel = UILabel().then {
         $0.textColor = .label
-        $0.font = .systemFont(ofSize: 20, weight: .heavy)
+        $0.font = .systemFont(ofSize: 20, weight: .bold)
     }
 
     private let descriptionLabel = UILabel().then {

--- a/AppStoreClone/AppStoreClone/Presentation/Home/ViewController/HomeViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/ViewController/HomeViewController.swift
@@ -16,6 +16,7 @@ final class HomeViewController: UIViewController {
     private let viewModel: HomeViewModel
     private let disposeBag = DisposeBag()
 
+    // TODO: DIContainer 구현
     private let searchRepository = DefaultSearchRepository(iTunesService: ITunesService())
     private lazy var fetchShowUseCase = FetchShowUseCase(repository: searchRepository)
     private lazy var searchResultViewModel = SearchResultViewModel(fetchShowUseCase: fetchShowUseCase)

--- a/AppStoreClone/AppStoreClone/Presentation/Home/ViewController/HomeViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/ViewController/HomeViewController.swift
@@ -10,7 +10,6 @@ import RxSwift
 import RxCocoa
 
 final class HomeViewController: UIViewController {
-
     // MARK: - Properties
 
     private let viewModel: HomeViewModel
@@ -18,6 +17,9 @@ final class HomeViewController: UIViewController {
 
     // MARK: - UI Components
 
+    private let searchController = UISearchController(
+        searchResultsController: SearchResultViewController()
+    )
     private let homeView = HomeView()
 
     // MARK: - Init, Deinit, required
@@ -25,7 +27,6 @@ final class HomeViewController: UIViewController {
     init(viewModel: HomeViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-        bind()
     }
 
     required init?(coder: NSCoder) {
@@ -40,12 +41,29 @@ final class HomeViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        viewModel.action.accept(.viewDidLoad)
+        setStyle()
+        setSearchController()
+        bind()
+    }
+
+    // MARK: - Set Style
+
+    private func setStyle() {
+        title = "Music"
+        self.navigationController?.navigationBar.prefersLargeTitles = true
+    }
+
+    // MARK: - Set SearchController
+    private func setSearchController() {
+        self.navigationItem.searchController = searchController
+        searchController.searchResultsUpdater = self
     }
 
     // MARK: - Bind
 
     private func bind() {
+        viewModel.action.accept(.viewDidLoad)
+
         viewModel.state.springSong
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, songs in
@@ -73,5 +91,11 @@ final class HomeViewController: UIViewController {
                 owner.homeView.updateSnapshot(with: songs, toSection: .winter)
             }
             .disposed(by: disposeBag)
+    }
+}
+
+extension HomeViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        searchController.showsSearchResultsController = true
     }
 }

--- a/AppStoreClone/AppStoreClone/Presentation/Home/ViewController/HomeViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/ViewController/HomeViewController.swift
@@ -99,6 +99,13 @@ final class HomeViewController: UIViewController {
                 owner.homeView.updateSnapshot(with: songs, toSection: .winter)
             }
             .disposed(by: disposeBag)
+
+        searchResultViewController.didTapHeader
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, _ in
+                owner.searchController.isActive = false
+            }
+            .disposed(by: disposeBag)
     }
 }
 

--- a/AppStoreClone/AppStoreClone/Presentation/Home/ViewController/HomeViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/ViewController/HomeViewController.swift
@@ -15,7 +15,11 @@ final class HomeViewController: UIViewController {
 
     private let viewModel: HomeViewModel
     private let disposeBag = DisposeBag()
-    private let searchResultViewController = SearchResultViewController()
+
+    private let searchRepository = DefaultSearchRepository(iTunesService: ITunesService())
+    private lazy var fetchShowUseCase = FetchShowUseCase(repository: searchRepository)
+    private lazy var searchResultViewModel = SearchResultViewModel(fetchShowUseCase: fetchShowUseCase)
+    private lazy var searchResultViewController = SearchResultViewController(viewModel: searchResultViewModel)
 
     // MARK: - UI Components
 
@@ -99,6 +103,8 @@ final class HomeViewController: UIViewController {
 
 extension HomeViewController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
-        searchController.showsSearchResultsController = true
+        guard let query = searchController.searchBar.text else { return }
+        searchController.showsSearchResultsController = !query.isEmpty
+        searchResultViewController.updateQuery(query)
     }
 }

--- a/AppStoreClone/AppStoreClone/Presentation/Home/ViewController/HomeViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/ViewController/HomeViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Then
 import RxSwift
 import RxCocoa
 
@@ -14,12 +15,14 @@ final class HomeViewController: UIViewController {
 
     private let viewModel: HomeViewModel
     private let disposeBag = DisposeBag()
+    private let searchResultViewController = SearchResultViewController()
 
     // MARK: - UI Components
 
-    private let searchController = UISearchController(
-        searchResultsController: SearchResultViewController()
-    )
+    private lazy var searchController = UISearchController(searchResultsController: searchResultViewController).then {
+        $0.searchBar.placeholder = "영화, 팟캐스트"
+        $0.searchResultsUpdater = self
+    }
     private let homeView = HomeView()
 
     // MARK: - Init, Deinit, required
@@ -56,7 +59,7 @@ final class HomeViewController: UIViewController {
     // MARK: - Set SearchController
     private func setSearchController() {
         self.navigationItem.searchController = searchController
-        searchController.searchResultsUpdater = self
+        self.navigationItem.hidesSearchBarWhenScrolling = false
     }
 
     // MARK: - Bind

--- a/AppStoreClone/AppStoreClone/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -42,6 +42,7 @@ final class HomeViewModel: ViewModelProtocol {
         action.bind { [weak self] action in
             switch action {
             case .viewDidLoad:
+                // TODO: observable들을 반환하는 메서드로 변경해서 concat으로 묶기
                 self?.fetchSpringSong()
                 self?.fetchSummerSong()
                 self?.fetchAutumnSong()

--- a/AppStoreClone/AppStoreClone/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -42,45 +42,28 @@ final class HomeViewModel: ViewModelProtocol {
         action.bind { [weak self] action in
             switch action {
             case .viewDidLoad:
-                // TODO: observable들을 반환하는 메서드로 변경해서 concat으로 묶기
-                self?.fetchSpringSong()
-                self?.fetchSummerSong()
-                self?.fetchAutumnSong()
-                self?.fetchWinterSong()
+                self?.fetchAllSeasonSong()
             }
         }
         .disposed(by: disposeBag)
     }
 
-    private func fetchSpringSong() {
-        fetchSeasonSongUseCase.execute(season: .spring)
-            .subscribe { [weak self] songs in
-                self?.state.springSong.accept(songs)
+    private func fetchAllSeasonSong() {
+        // 계절별 추천곡 로드 병렬 처리
+        Observable.merge(
+            Season.allCases.map { season in
+                fetchSeasonSongUseCase.execute(season: season)
+                    .map { songs in (season, songs) }
             }
-            .disposed(by: disposeBag)
-    }
-
-    private func fetchSummerSong() {
-        fetchSeasonSongUseCase.execute(season: .summer)
-            .subscribe { [weak self] songs in
-                self?.state.summerSong.accept(songs)
+        )
+        .subscribe { [weak self] season, songs in
+            switch season {
+            case .spring: self?.state.springSong.accept(songs)
+            case .summer: self?.state.summerSong.accept(songs)
+            case .autumn: self?.state.autumnSong.accept(songs)
+            case .winter: self?.state.winterSong.accept(songs)
             }
-            .disposed(by: disposeBag)
-    }
-
-    private func fetchAutumnSong() {
-        fetchSeasonSongUseCase.execute(season: .autumn)
-            .subscribe { [weak self] songs in
-                self?.state.autumnSong.accept(songs)
-            }
-            .disposed(by: disposeBag)
-    }
-
-    private func fetchWinterSong() {
-        fetchSeasonSongUseCase.execute(season: .winter)
-            .subscribe { [weak self] songs in
-                self?.state.winterSong.accept(songs)
-            }
-            .disposed(by: disposeBag)
+        }
+        .disposed(by: disposeBag)
     }
 }

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/Model/Show+UI.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/Model/Show+UI.swift
@@ -1,0 +1,17 @@
+//
+//  Show+UI.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/14/25.
+//
+
+import UIKit
+
+extension Show {
+    var color: UIColor {
+        switch kind {
+        case .movie: UIColor.brown.withAlphaComponent(0.2)
+        case .podcast: UIColor.cyan.withAlphaComponent(0.2)
+        }
+    }
+}

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/VIewModel/SearchResultViewModel.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/VIewModel/SearchResultViewModel.swift
@@ -6,3 +6,49 @@
 //
 
 import Foundation
+import RxSwift
+import RxRelay
+
+final class SearchResultViewModel: ViewModelProtocol {
+    enum Action {
+        case didQueryChanged(String)
+    }
+
+    struct State {
+        let show = BehaviorRelay<[Show]>(value: [])
+    }
+
+    // MARK: - Properties
+
+    private let fetchShowUseCase: FetchShowUseCase
+    let action = PublishRelay<Action>()
+    var state = State()
+    let disposeBag = DisposeBag()
+
+    // MARK: - Init, Deinit, required
+
+    init(fetchShowUseCase: FetchShowUseCase) {
+        self.fetchShowUseCase = fetchShowUseCase
+        bindActions()
+    }
+
+    // MARK: - Methods
+
+    func bindActions() {
+        action.bind { [weak self] action in
+            switch action {
+            case .didQueryChanged(let query):
+                self?.fetchShow(by: query)
+            }
+        }
+        .disposed(by: disposeBag)
+    }
+
+    private func fetchShow(by query: String) {
+        fetchShowUseCase.execute(searchQuery: query)
+            .subscribe { [weak self] shows in
+                self?.state.show.accept(shows)
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/VIewModel/SearchResultViewModel.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/VIewModel/SearchResultViewModel.swift
@@ -15,6 +15,7 @@ final class SearchResultViewModel: ViewModelProtocol {
     }
 
     struct State {
+        let searchKeyword = BehaviorRelay<String>(value: "")
         let show = BehaviorRelay<[Show]>(value: [])
     }
 
@@ -38,10 +39,15 @@ final class SearchResultViewModel: ViewModelProtocol {
         action.bind { [weak self] action in
             switch action {
             case .didQueryChanged(let query):
+                self?.setSearchKeyword(for: query)
                 self?.fetchShow(by: query)
             }
         }
         .disposed(by: disposeBag)
+    }
+
+    private func setSearchKeyword(for keyword: String) {
+        state.searchKeyword.accept(keyword)
     }
 
     private func fetchShow(by query: String) {

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/VIewModel/SearchResultViewModel.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/VIewModel/SearchResultViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  SearchResultViewModel.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/14/25.
+//
+
+import Foundation

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/SearchResultView.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/SearchResultView.swift
@@ -75,7 +75,8 @@ final class SearchResultView: UIView {
                     for: indexPath
                 ) as! ShowCell
 
-                cell.updateCell(with: show.title, show.artist, show.artworkImageURL, backgroundColor: show.color)
+                let kind = show.kind == .movie ? "Movie" : "Podcast"
+                cell.updateCell(with: show.title, kind, show.artworkImageURL, backgroundColor: show.color)
 
                 return cell
             })

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/SearchResultView.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/SearchResultView.swift
@@ -89,13 +89,6 @@ final class SearchResultView: UIView {
 
         var snapshot = NSDiffableDataSourceSnapshot<SearchResultSection, Show>()
         snapshot.appendSections(SearchResultSection.allCases)
-        snapshot.appendItems([
-            Show(kind: .movie, title: "dsa", artist: "dsa", artworkImageURL: "sd", genre: "dsa", releaseDate: Date()),
-            Show(kind: .movie, title: "dsa1", artist: "dsa", artworkImageURL: "sd", genre: "dsa", releaseDate: Date()),
-            Show(kind: .movie, title: "dsa2", artist: "dsa", artworkImageURL: "sd", genre: "dsa", releaseDate: Date()),
-            Show(kind: .movie, title: "dsa3", artist: "dsa", artworkImageURL: "sd", genre: "dsa", releaseDate: Date()),
-            Show(kind: .movie, title: "dsa4", artist: "dsa", artworkImageURL: "sd", genre: "dsa", releaseDate: Date())
-        ], toSection: .show)
         dataSource?.apply(snapshot)
     }
 

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/SearchResultView.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/SearchResultView.swift
@@ -19,6 +19,7 @@ final class SearchResultView: UIView {
         frame: .zero,
         collectionViewLayout: createCollectionViewLayout()
     ).then {
+        $0.keyboardDismissMode = .onDrag
         $0.register(ShowCell.self,forCellWithReuseIdentifier: ShowCell.identifier)
         $0.register(
             SearchResultHeader.self,

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/SearchResultView.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/SearchResultView.swift
@@ -14,6 +14,7 @@ final class SearchResultView: UIView {
     // MARK: - Properties
 
     let headerTitle = BehaviorRelay<String>(value: "")
+    let didTapHeader = PublishRelay<Void>()
     private let disposeBag = DisposeBag()
     private var dataSource: UICollectionViewDiffableDataSource<SearchResultSection, Show>?
 
@@ -95,6 +96,12 @@ final class SearchResultView: UIView {
                     header.updateHeader(query)
                 }
                 .disposed(by: disposeBag)
+
+            header.didTapTitle
+                .subscribe { _ in
+                    self.didTapHeader.accept(())
+                }
+                .disposed(by: header.disposeBag)
 
             return header
         }

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/SearchResultView.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/SearchResultView.swift
@@ -1,0 +1,156 @@
+//
+//  SearchResultView.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/14/25.
+//
+
+import UIKit
+
+final class SearchResultView: UIView {
+
+    // MARK: - Properties
+
+    private var dataSource: UICollectionViewDiffableDataSource<SearchResultSection, Show>?
+
+    // MARK: - UI Components
+
+    private lazy var collectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: createCollectionViewLayout()
+    ).then {
+        $0.register(ShowCell.self,forCellWithReuseIdentifier: ShowCell.identifier)
+        $0.register(
+            SearchResultHeader.self,
+            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
+            withReuseIdentifier: SearchResultHeader.identifier
+        )
+    }
+
+    // MARK: - Init, Deinit, required
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setStyle()
+        setHierarchy()
+        setConstraints()
+        setDataSource()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    // MARK: - Style Helper
+
+    private func setStyle() {
+        backgroundColor = .systemBackground
+    }
+
+    // MARK: - Hierarchy Helper
+
+    private func setHierarchy() {
+        [
+            collectionView,
+        ].forEach { addSubview($0) }
+    }
+
+    // MARK: - Constraints Helper
+
+    private func setConstraints() {
+        collectionView.snp.makeConstraints {
+            $0.directionalEdges.equalToSuperview()
+        }
+    }
+
+    // MARK: - DataSource Helper
+
+    private func setDataSource() {
+        dataSource = .init(
+            collectionView: collectionView,
+            cellProvider: { collectionView, indexPath, show in
+                let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: ShowCell.identifier,
+                    for: indexPath
+                ) as! ShowCell
+
+                cell.updateCell(with: show.title, show.artist, show.artworkImageURL, backgroundColor: show.color)
+
+                return cell
+            })
+
+        dataSource?.supplementaryViewProvider = { collectionView, kind, indexPath in
+            let header = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: SearchResultHeader.identifier, for: indexPath) as! SearchResultHeader
+
+            header.updateHeader("Hello")
+
+            return header
+        }
+
+        var snapshot = NSDiffableDataSourceSnapshot<SearchResultSection, Show>()
+        snapshot.appendSections(SearchResultSection.allCases)
+        snapshot.appendItems([
+            Show(kind: .movie, title: "dsa", artist: "dsa", artworkImageURL: "sd", genre: "dsa", releaseDate: Date()),
+            Show(kind: .movie, title: "dsa1", artist: "dsa", artworkImageURL: "sd", genre: "dsa", releaseDate: Date()),
+            Show(kind: .movie, title: "dsa2", artist: "dsa", artworkImageURL: "sd", genre: "dsa", releaseDate: Date()),
+            Show(kind: .movie, title: "dsa3", artist: "dsa", artworkImageURL: "sd", genre: "dsa", releaseDate: Date()),
+            Show(kind: .movie, title: "dsa4", artist: "dsa", artworkImageURL: "sd", genre: "dsa", releaseDate: Date())
+        ], toSection: .show)
+        dataSource?.apply(snapshot)
+    }
+
+    // MARK: - Methods
+
+    private func createCollectionViewLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewCompositionalLayout { sectionIndex, _
+            -> NSCollectionLayoutSection? in
+
+            let section = SearchResultSection.allCases[sectionIndex]
+            switch section {
+            case .show:
+                let headerSize = NSCollectionLayoutSize(
+                    widthDimension: .fractionalWidth(1),
+                    heightDimension: .estimated(50)
+                )
+                let header = NSCollectionLayoutBoundarySupplementaryItem(
+                    layoutSize: headerSize,
+                    elementKind: UICollectionView.elementKindSectionHeader,
+                    alignment: .topLeading
+                )
+
+                let itemSize = NSCollectionLayoutSize(
+                    widthDimension: .fractionalWidth(1),
+                    heightDimension: .fractionalHeight(1)
+                )
+                let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+                let groupSize = NSCollectionLayoutSize(
+                    widthDimension: .fractionalWidth(1),
+                    heightDimension: .fractionalWidth(1.1)
+                )
+                let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+
+                let section = NSCollectionLayoutSection(group: group)
+                section.interGroupSpacing = 32
+                section.contentInsets = .init(top: 0, leading: 16, bottom: 40, trailing: 16)
+                section.boundarySupplementaryItems = [header]
+
+                return section
+            }
+        }
+        return layout
+    }
+
+    func updateSnapshot(with items: [Show], toSection section: SearchResultSection) {
+        guard var snapshot = dataSource?.snapshot(for: section) else { return }
+        snapshot.deleteAll()
+        snapshot.append(items)
+        dataSource?.apply(snapshot, to: section)
+    }
+}
+
+extension SearchResultView {
+    enum SearchResultSection: CaseIterable, Hashable {
+        case show
+    }
+}

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/Subview/SearchResultHeader.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/Subview/SearchResultHeader.swift
@@ -8,14 +8,22 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
+import RxRelay
 
 final class SearchResultHeader: UICollectionReusableView {
+
+    // MARK: - Properties
+
+    let didTapTitle = PublishRelay<Void>()
+    var disposeBag = DisposeBag()
 
     // MARK: - UIComponents
 
     private let titleLabel = UILabel().then {
         $0.textColor = .label
         $0.font = .systemFont(ofSize: 36, weight: .bold)
+        $0.isUserInteractionEnabled = true
     }
 
     // MARK: - Init, Deinit, required
@@ -24,6 +32,7 @@ final class SearchResultHeader: UICollectionReusableView {
         super.init(frame: frame)
         setHierarchy()
         setConstraints()
+        bind()
     }
 
     required init?(coder: NSCoder) {
@@ -38,6 +47,13 @@ final class SearchResultHeader: UICollectionReusableView {
         ].forEach { addSubview($0) }
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        updateHeader(nil)
+        disposeBag = DisposeBag()
+        bind()
+    }
+
     // MARK: - Constraints Helper
 
     private func setConstraints() {
@@ -49,7 +65,18 @@ final class SearchResultHeader: UICollectionReusableView {
 
     // MARK: - Methods
 
-    func updateHeader(_ title: String) {
+    private func bind() {
+        let tapGesture = UITapGestureRecognizer()
+        titleLabel.addGestureRecognizer(tapGesture)
+
+        tapGesture.rx.event
+            .bind(onNext: { [weak self] _ in
+                self?.didTapTitle.accept(())
+            })
+            .disposed(by: disposeBag)
+    }
+
+    func updateHeader(_ title: String?) {
         titleLabel.text = title
     }
 }

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/Subview/SearchResultHeader.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/Subview/SearchResultHeader.swift
@@ -1,0 +1,55 @@
+//
+//  SearchResultHeader.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/14/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class SearchResultHeader: UICollectionReusableView {
+
+    // MARK: - UIComponents
+
+    private let titleLabel = UILabel().then {
+        $0.textColor = .label
+        $0.font = .systemFont(ofSize: 36, weight: .bold)
+    }
+
+    // MARK: - Init, Deinit, required
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setHierarchy()
+        setConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Hierarchy Helper
+
+    private func setHierarchy() {
+        [
+            titleLabel,
+        ].forEach { addSubview($0) }
+    }
+
+    // MARK: - Constraints Helper
+
+    private func setConstraints() {
+        titleLabel.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview().inset(20)
+            $0.directionalHorizontalEdges.equalToSuperview()
+        }
+    }
+
+    // MARK: - Methods
+
+    func updateHeader(_ title: String) {
+        titleLabel.text = title
+    }
+}

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/Subview/ShowCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/Subview/ShowCell.swift
@@ -14,6 +14,7 @@ final class ShowCell: UICollectionViewCell {
 
     // MARK: - Properties
 
+    private var imageLoadTask: Task<Void, Never>?
     private var disposeBag = DisposeBag()
 
     // MARK: - UI Components
@@ -88,14 +89,19 @@ final class ShowCell: UICollectionViewCell {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        imageLoadTask?.cancel()
+        updateCell(with: nil, nil, nil, backgroundColor: .clear)
         disposeBag = DisposeBag()
     }
 
-    func updateCell(with title: String, _ showKind: String, _ artworkImageURL: String, backgroundColor: UIColor) {
+    func updateCell(with title: String?, _ showKind: String?, _ artworkImageURL: String?, backgroundColor: UIColor) {
         showKindLabel.text = showKind
         titleLabel.text = title
         contentView.backgroundColor = backgroundColor
-        Task {
+
+        guard let artworkImageURL else { return }
+        // TODO: Rx 사용
+        imageLoadTask = Task {
             artworkImageView.image = await ImageLoader.shared.loadImage(from: artworkImageURL)
         }
     }

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/Subview/ShowCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/Subview/ShowCell.swift
@@ -1,0 +1,102 @@
+//
+//  ShowCell.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/14/25.
+//
+
+import UIKit
+import SnapKit
+import Then
+import RxSwift
+
+final class ShowCell: UICollectionViewCell {
+
+    // MARK: - Properties
+
+    private var disposeBag = DisposeBag()
+
+    // MARK: - UI Components
+
+    private let showKindLabel = UILabel().then {
+        $0.textColor = .secondaryLabel
+        $0.font = .systemFont(ofSize: 16, weight: .bold)
+    }
+
+    private let titleLabel = UILabel().then {
+        $0.textColor = .label
+        $0.font = .systemFont(ofSize: 22, weight: .bold)
+    }
+
+    private let artworkImageView = UIImageView().then {
+        $0.contentMode = .scaleAspectFill
+        $0.clipsToBounds = true
+        $0.backgroundColor = .quaternarySystemFill
+    }
+
+    // MARK: - Init, Deinit, requiered
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setStyle()
+        setHierarchy()
+        setConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    // MARK: - Style Helper
+
+    private func setStyle() {
+        contentView.clipsToBounds = true
+        contentView.layer.cornerRadius = 10
+    }
+
+    // MARK: - Hierarchy Helper
+
+    private func setHierarchy() {
+        [
+            showKindLabel,
+            titleLabel,
+            artworkImageView,
+        ].forEach { contentView.addSubview($0) }
+    }
+
+    // MARK: - Constraints Helper
+
+    private func setConstraints() {
+
+        showKindLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(16)
+            $0.directionalHorizontalEdges.equalToSuperview().inset(20)
+        }
+
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(showKindLabel.snp.bottom)
+            $0.directionalHorizontalEdges.equalToSuperview().inset(20)
+        }
+
+        artworkImageView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(8)
+            $0.directionalHorizontalEdges.bottom.equalToSuperview()
+        }
+    }
+
+    // MARK: - Methods
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
+    }
+
+    func updateCell(with title: String, _ showKind: String, _ artworkImageURL: String, backgroundColor: UIColor) {
+        showKindLabel.text = showKind
+        titleLabel.text = title
+        contentView.backgroundColor = backgroundColor
+        Task {
+            artworkImageView.image = await ImageLoader.shared.loadImage(from: artworkImageURL)
+        }
+    }
+}

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/ViewController/SearchResultViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/ViewController/SearchResultViewController.swift
@@ -14,6 +14,7 @@ final class SearchResultViewController: UIViewController {
     // MARK: - Properties
 
     private let viewModel: SearchResultViewModel
+    let didTapHeader = PublishRelay<Void>()
     private let disposeBag = DisposeBag()
 
     // MARK: - UI Components
@@ -56,6 +57,12 @@ final class SearchResultViewController: UIViewController {
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, shows in
                 owner.searchResultView.updateSnapshot(with: shows, toSection: .show)
+            }
+            .disposed(by: disposeBag)
+
+        searchResultView.didTapHeader
+            .subscribe { [weak self] _ in
+                self?.didTapHeader.accept(())
             }
             .disposed(by: disposeBag)
     }

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/ViewController/SearchResultViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/ViewController/SearchResultViewController.swift
@@ -6,10 +6,32 @@
 //
 
 import UIKit
+import RxSwift
+import RxCocoa
 
 final class SearchResultViewController: UIViewController {
 
+    // MARK: - Properties
+
+    private let viewModel: SearchResultViewModel
+    private let disposeBag = DisposeBag()
+
+    // MARK: - UI Components
+
     private let searchResultView = SearchResultView()
+
+    // MARK: - Init, Deinit, required
+
+    init(viewModel: SearchResultViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Life Cycles
 
     override func loadView() {
         view = searchResultView
@@ -17,5 +39,23 @@ final class SearchResultViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        bind()
+    }
+
+    // MARK: - Bind
+
+    private func bind() {
+        viewModel.state.show
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, shows in
+                owner.searchResultView.updateSnapshot(with: shows, toSection: .show)
+            }
+            .disposed(by: disposeBag)
+    }
+
+    // MARK: - Methods
+
+    func updateQuery(_ query: String) {
+        viewModel.action.accept(.didQueryChanged(query))
     }
 }

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/ViewController/SearchResultViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/ViewController/SearchResultViewController.swift
@@ -45,7 +45,14 @@ final class SearchResultViewController: UIViewController {
     // MARK: - Bind
 
     private func bind() {
+        viewModel.state.searchKeyword
+            .bind(with: self) { owner, keyword in
+                owner.searchResultView.headerTitle.accept(keyword)
+            }
+            .disposed(by: disposeBag)
+
         viewModel.state.show
+            .throttle(.seconds(2), scheduler: MainScheduler.instance)
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, shows in
                 owner.searchResultView.updateSnapshot(with: shows, toSection: .show)

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/ViewController/SearchResultViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/ViewController/SearchResultViewController.swift
@@ -8,8 +8,14 @@
 import UIKit
 
 final class SearchResultViewController: UIViewController {
+
+    private let searchResultView = SearchResultView()
+
+    override func loadView() {
+        view = searchResultView
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .cyan.withAlphaComponent(0.3)
     }
 }

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/ViewController/SearchResultViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/ViewController/SearchResultViewController.swift
@@ -1,0 +1,15 @@
+//
+//  SearchResultViewController.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/13/25.
+//
+
+import UIKit
+
+final class SearchResultViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .cyan.withAlphaComponent(0.3)
+    }
+}


### PR DESCRIPTION
## 💭 작업 내용
- Show 도메인 구현
- 영화, 팟캐스트 fetch
- 검색 화면 UI 구현

## 🌤️ PR POINT
- Song과 Show 도메인을 다른 레이어에서 extension으로 확장해 사용하는 구조에 대해 철회하는 방향으로 재검토중
- Service의 fetch 메서드에서 제네릭을 활용하여 일반화

## 📸 스크린샷
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 13 mini - 홈 화면 | <img src = "https://github.com/user-attachments/assets/79f8d623-aadd-48c2-b5b5-657ad56a10bd" width ="250"> |
| iPhone 13 mini - 검색 결과 화면 | <img src = "https://github.com/user-attachments/assets/e676debc-85c9-434f-8bd6-3611fa044faf" width ="250"> |

## 🌈 관련 이슈
- Resolved: #9

