### PR TITLE
[Feat] #15 - 상세화면 구현

### DIFF
--- a/AppStoreClone/AppStoreClone/Data/Mapper/ShowMapper.swift
+++ b/AppStoreClone/AppStoreClone/Data/Mapper/ShowMapper.swift
@@ -14,6 +14,7 @@ struct ShowMapper {
         let artist = dto.artistName
         let artworkImageURL = dto.artworkImageURL
         let genre = dto.primaryGenreName
+        let detailViewURL = dto.webViewURL
 
         let isoFormatter = ISO8601DateFormatter()
         guard let date = isoFormatter.date(from: dto.releaseDate) else { return nil }
@@ -24,7 +25,8 @@ struct ShowMapper {
             artist: artist,
             artworkImageURL: artworkImageURL,
             genre: genre,
-            releaseDate: date
+            releaseDate: date,
+            detailViewURL: detailViewURL,
         )
     }
 }

--- a/AppStoreClone/AppStoreClone/Data/Mapper/SongMapper.swift
+++ b/AppStoreClone/AppStoreClone/Data/Mapper/SongMapper.swift
@@ -13,6 +13,13 @@ struct SongMapper {
         let artist = dto.artistName
         let artworkURL = dto.artworkURL
         let album = dto.collectionName
-        return Song(title: title, artist: artist, artworkImageURL: artworkURL, album: album)
+        let detailViewURL = dto.detailViewURL
+        return Song(
+            title: title,
+            artist: artist,
+            artworkImageURL: artworkURL,
+            album: album,
+            detailViewURL: detailViewURL,
+        )
     }
 }

--- a/AppStoreClone/AppStoreClone/Data/Model/SearchMediaType.swift
+++ b/AppStoreClone/AppStoreClone/Data/Model/SearchMediaType.swift
@@ -19,9 +19,9 @@ enum SearchMediaType {
             let limit = season.resultLimit
             return "media=music&entity=song&genreId=51&term=\(searchTerm)&limit=\(limit)"
         case .movie(let searchTerm):
-            return "media=movie&entity=movie&term=\(searchTerm)&limit=5"
+            return "media=movie&entity=movie&term=\(searchTerm)&limit=20"
         case .podcast(let searchTerm):
-            return "media=podcast&entity=podcast&term=\(searchTerm)&limit=5"
+            return "media=podcast&entity=podcast&term=\(searchTerm)&limit=20"
         }
     }
 }

--- a/AppStoreClone/AppStoreClone/Data/Model/ShowDTO.swift
+++ b/AppStoreClone/AppStoreClone/Data/Model/ShowDTO.swift
@@ -14,6 +14,7 @@ struct ShowDTO: Decodable {
     let artworkImageURL: String
     let primaryGenreName: String
     let releaseDate: String
+    let webViewURL: String
 
     enum CodingKeys: String, CodingKey {
         case kind
@@ -22,5 +23,6 @@ struct ShowDTO: Decodable {
         case artworkImageURL = "artworkUrl30"
         case primaryGenreName
         case releaseDate
+        case webViewURL = "collectionViewUrl"
     }
 }

--- a/AppStoreClone/AppStoreClone/Data/Model/ShowDTO.swift
+++ b/AppStoreClone/AppStoreClone/Data/Model/ShowDTO.swift
@@ -14,7 +14,7 @@ struct ShowDTO: Decodable {
     let artworkImageURL: String
     let primaryGenreName: String
     let releaseDate: String
-    let webViewURL: String
+    let webViewURL: String?
 
     enum CodingKeys: String, CodingKey {
         case kind

--- a/AppStoreClone/AppStoreClone/Data/Model/SongDTO.swift
+++ b/AppStoreClone/AppStoreClone/Data/Model/SongDTO.swift
@@ -12,11 +12,13 @@ struct SongDTO: Decodable {
     let artistName: String
     let artworkURL: String
     let collectionName: String
+    let detailViewURL: String?
 
     enum CodingKeys: String, CodingKey {
         case trackName
         case artistName
         case artworkURL = "artworkUrl30"
         case collectionName
+        case detailViewURL = "trackViewUrl"
     }
 }

--- a/AppStoreClone/AppStoreClone/Data/Network/ITunesService.swift
+++ b/AppStoreClone/AppStoreClone/Data/Network/ITunesService.swift
@@ -22,15 +22,18 @@ final class ITunesService {
         }
 
         return Single.create { observer in
-            Task {
+            let task = URLSession.shared.dataTask(with: url) { data, _, _ in
                 do {
-                    let (data, _) = try await URLSession.shared.data(from: url)
+                    guard let data else { return }
                     let decodedData = try JSONDecoder().decode(SearchResponse<T>.self, from: data)
                     observer(.success(decodedData.results))
                 } catch {
                     observer(.failure(error))
                 }
             }
+
+            task.resume()
+
             return Disposables.create()
         }
     }

--- a/AppStoreClone/AppStoreClone/Data/Network/ImageLoader.swift
+++ b/AppStoreClone/AppStoreClone/Data/Network/ImageLoader.swift
@@ -5,18 +5,43 @@
 //  Created by 곽다은 on 5/12/25.
 //
 
-import Foundation
 import UIKit
+import RxSwift
 
 final class ImageLoader {
     static let shared = ImageLoader()
 
     private init() {}
 
-    func loadImage(from urlString: String) async -> UIImage? {
-        let bigImageURLString = urlString.replacingOccurrences(of: "30x30bb.jpg", with: "1024x1024bb.jpg")
-        guard let url = URL(string: bigImageURLString) else { return nil }
-        guard let (data, _ ) = try? await URLSession.shared.data(from: url) else { return nil }
-        return UIImage(data: data)
+    func loadImage(from urlString: String) -> Single<UIImage?> {
+        let bigImageURLString = urlString.replacingOccurrences(
+            of: "30x30bb.jpg",
+            with: "1024x1024bb.jpg"
+        )
+        guard let url = URL(string: bigImageURLString) else {
+            return Single.create { observer in
+                observer(.failure(ImageLoadError.invalidURL))
+                return Disposables.create()
+            }
+        }
+
+        return Single.create { observer in
+            Task {
+                do {
+                    let (data, _ ) = try await URLSession.shared.data(from: url)
+                    let image = UIImage(data: data)
+                    observer(.success(image))
+                } catch {
+                    observer(.failure(error))
+                }
+            }
+            return Disposables.create()
+        }
+    }
+}
+
+extension ImageLoader {
+    enum ImageLoadError: Error {
+        case invalidURL
     }
 }

--- a/AppStoreClone/AppStoreClone/Domain/Entity/Show.swift
+++ b/AppStoreClone/AppStoreClone/Domain/Entity/Show.swift
@@ -14,4 +14,5 @@ struct Show: Hashable {
     let artworkImageURL: String
     let genre: String
     let releaseDate: Date
+    let detailViewURL: String
 }

--- a/AppStoreClone/AppStoreClone/Domain/Entity/Show.swift
+++ b/AppStoreClone/AppStoreClone/Domain/Entity/Show.swift
@@ -14,5 +14,5 @@ struct Show: Hashable {
     let artworkImageURL: String
     let genre: String
     let releaseDate: Date
-    let detailViewURL: String
+    let detailViewURL: String?
 }

--- a/AppStoreClone/AppStoreClone/Domain/Entity/Song.swift
+++ b/AppStoreClone/AppStoreClone/Domain/Entity/Song.swift
@@ -12,4 +12,5 @@ struct Song: Hashable {
     let artist: String
     let artworkImageURL: String
     let album: String
+    let detailViewURL: String?
 }

--- a/AppStoreClone/AppStoreClone/Presentation/Detail/ViewController/DetailViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Detail/ViewController/DetailViewController.swift
@@ -8,21 +8,32 @@
 import WebKit
 import SnapKit
 import Then
+import RxSwift
 
 final class DetailViewController: UIViewController, WKUIDelegate {
 
-    var webView: WKWebView?
-    private let url: URL?
+    // MARK: - Properties
 
-    init(url: URL) {
-        self.url = url
+    private let viewModel: DetailViewModel
+    private let disposeBag = DisposeBag()
+
+    // MARK: - UI Components
+
+    var webView: WKWebView?
+
+    // MARK: - Init, Deinit, required
+
+    init(viewModel: DetailViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
+    // MARK: - View Life Cycles
+
     override func loadView() {
         let webConfiguration = WKWebViewConfiguration()
         webView = WKWebView(frame: .zero, configuration: webConfiguration)
@@ -32,12 +43,24 @@ final class DetailViewController: UIViewController, WKUIDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        bind()
+    }
 
-        guard let url else { return }
+    // MARK: - Bind
+
+    private func bind() {
+        viewModel.state.webViewURL
+            .compactMap { $0 }
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(onNext: loadWebView)
+            .disposed(by: disposeBag)
+
+    }
+
+    private func loadWebView(of url: URL) {
         let request = URLRequest(url: url)
         if let webView {
             webView.load(request)
         }
     }
-
 }

--- a/AppStoreClone/AppStoreClone/Presentation/Detail/ViewController/DetailViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Detail/ViewController/DetailViewController.swift
@@ -1,0 +1,43 @@
+//
+//  DetailViewController.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/16/25.
+//
+
+import WebKit
+import SnapKit
+import Then
+
+final class DetailViewController: UIViewController, WKUIDelegate {
+
+    var webView: WKWebView?
+    private let url: URL?
+
+    init(url: URL) {
+        self.url = url
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func loadView() {
+        let webConfiguration = WKWebViewConfiguration()
+        webView = WKWebView(frame: .zero, configuration: webConfiguration)
+        webView?.uiDelegate = self
+        view = webView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        guard let url else { return }
+        let request = URLRequest(url: url)
+        if let webView {
+            webView.load(request)
+        }
+    }
+
+}

--- a/AppStoreClone/AppStoreClone/Presentation/Detail/ViewModel/DetailViewModel.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Detail/ViewModel/DetailViewModel.swift
@@ -1,0 +1,30 @@
+//
+//  DetailViewModel.swift
+//  AppStoreClone
+//
+//  Created by 곽다은 on 5/16/25.
+//
+
+import Foundation
+import RxSwift
+import RxRelay
+
+final class DetailViewModel: ViewModelProtocol {
+    enum Action {}
+
+    struct State {
+        let webViewURL = BehaviorRelay<URL?>(value: nil)
+    }
+
+    // MARK: - Properties
+
+    var action = PublishRelay<Action>()
+    var state = State()
+    let disposeBag = DisposeBag()
+
+    // MARK: - Init, Deinit, required
+
+    init(webViewURL: URL) {
+        state.webViewURL.accept(webViewURL)
+    }
+}

--- a/AppStoreClone/AppStoreClone/Presentation/Home/View/HomeView.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/View/HomeView.swift
@@ -8,12 +8,16 @@
 import UIKit
 import SnapKit
 import Then
+import RxSwift
+import RxCocoa
 
 final class HomeView: UIView {
 
     // MARK: - Properties
 
     private var dataSource: UICollectionViewDiffableDataSource<Season, Song>?
+    let didTapCell = PublishRelay<IndexPath>()
+    private var disposeBag = DisposeBag()
 
     // MARK: - UI Components
 
@@ -45,6 +49,7 @@ final class HomeView: UIView {
         setHierarchy()
         setConstraints()
         setDataSource()
+        bind()
     }
     
     required init?(coder: NSCoder) {
@@ -71,6 +76,15 @@ final class HomeView: UIView {
         collectionView.snp.makeConstraints {
             $0.directionalEdges.equalToSuperview()
         }
+    }
+
+    // MARK: - Bind
+
+    private func bind() {
+        collectionView.rx.itemSelected
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(onNext: didTapCell.accept)
+            .disposed(by: disposeBag)
     }
 
     // MARK: - DataSource Helper

--- a/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicBannerCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicBannerCell.swift
@@ -93,11 +93,18 @@ final class MusicBannerCell: UICollectionViewCell {
     }
 
     func updateCell(with title: String?, _ artist: String?, _ artworkImageURL: String?) {
-        guard let artworkImageURL else { return }
-        Task {
-            artworkImageView.image = await ImageLoader.shared.loadImage(from: artworkImageURL)
-        }
         songTitleLabel.text = title
         artistLabel.text = artist
+        updateImageView(for: artworkImageURL)
+    }
+
+    private func updateImageView(for url: String?) {
+        guard let url else {
+            artworkImageView.image = nil
+            return
+        }
+        Task {
+            artworkImageView.image = await ImageLoader.shared.loadImage(from: url)
+        }
     }
 }

--- a/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicBannerCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicBannerCell.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 import Then
 import RxSwift
+import RxCocoa
 
 final class MusicBannerCell: UICollectionViewCell {
 
@@ -103,8 +104,12 @@ final class MusicBannerCell: UICollectionViewCell {
             artworkImageView.image = nil
             return
         }
-        Task {
-            artworkImageView.image = await ImageLoader.shared.loadImage(from: url)
-        }
+        ImageLoader.shared.loadImage(from: url)
+            .asObservable()
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, image in
+                owner.artworkImageView.image = image
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicBannerCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicBannerCell.swift
@@ -105,7 +105,6 @@ final class MusicBannerCell: UICollectionViewCell {
             return
         }
         ImageLoader.shared.loadImage(from: url)
-            .asObservable()
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, image in
                 owner.artworkImageView.image = image

--- a/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicCompactCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicCompactCell.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 import Then
 import RxSwift
+import RxCocoa
 
 final class MusicCompactCell: UICollectionViewCell {
 
@@ -110,7 +111,6 @@ final class MusicCompactCell: UICollectionViewCell {
         _ artworkImageURL: String?,
         _ album: String?
     ) {
-
         songTitleLabel.text = title
         artistLabel.text = artist
         albumLabel.text = album
@@ -122,8 +122,12 @@ final class MusicCompactCell: UICollectionViewCell {
             artworkImageView.image = nil
             return
         }
-        Task {
-            artworkImageView.image = await ImageLoader.shared.loadImage(from: url)
-        }
+        ImageLoader.shared.loadImage(from: url)
+            .asObservable()
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, image in
+                owner.artworkImageView.image = image
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicCompactCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicCompactCell.swift
@@ -123,7 +123,6 @@ final class MusicCompactCell: UICollectionViewCell {
             return
         }
         ImageLoader.shared.loadImage(from: url)
-            .asObservable()
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, image in
                 owner.artworkImageView.image = image

--- a/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicCompactCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/View/Subview/MusicCompactCell.swift
@@ -110,12 +110,20 @@ final class MusicCompactCell: UICollectionViewCell {
         _ artworkImageURL: String?,
         _ album: String?
     ) {
-        guard let artworkImageURL else { return }
-        Task {
-            artworkImageView.image = await ImageLoader.shared.loadImage(from: artworkImageURL)
-        }
+
         songTitleLabel.text = title
         artistLabel.text = artist
         albumLabel.text = album
+        updateImageView(for: artworkImageURL)
+    }
+
+    private func updateImageView(for url: String?) {
+        guard let url else {
+            artworkImageView.image = nil
+            return
+        }
+        Task {
+            artworkImageView.image = await ImageLoader.shared.loadImage(from: url)
+        }
     }
 }

--- a/AppStoreClone/AppStoreClone/Presentation/Home/ViewController/HomeViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/ViewController/HomeViewController.swift
@@ -72,6 +72,11 @@ final class HomeViewController: UIViewController {
     private func bind() {
         viewModel.action.accept(.viewDidLoad)
 
+        homeView.didTapCell
+            .map(HomeViewModel.Action.didSelectedSong)
+            .bind(to: viewModel.action)
+            .disposed(by: disposeBag)
+
         viewModel.state.springSong
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, songs in
@@ -97,6 +102,15 @@ final class HomeViewController: UIViewController {
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, songs in
                 owner.homeView.updateSnapshot(with: songs, toSection: .winter)
+            }
+            .disposed(by: disposeBag)
+
+        viewModel.state.selectedSong
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, url in
+                let viewModel = DetailViewModel(webViewURL: url)
+                let viewController = DetailViewController(viewModel: viewModel)
+                owner.present(viewController, animated: true)
             }
             .disposed(by: disposeBag)
 

--- a/AppStoreClone/AppStoreClone/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -13,6 +13,7 @@ final class HomeViewModel: ViewModelProtocol {
 
     enum Action {
         case viewDidLoad
+        case didSelectedSong(IndexPath)
     }
 
     struct State {
@@ -20,6 +21,7 @@ final class HomeViewModel: ViewModelProtocol {
         let summerSong = BehaviorRelay<[Song]>(value: [])
         let autumnSong = BehaviorRelay<[Song]>(value: [])
         let winterSong = BehaviorRelay<[Song]>(value: [])
+        let selectedSong = PublishRelay<URL>()
     }
 
     // MARK: - Properties
@@ -43,6 +45,8 @@ final class HomeViewModel: ViewModelProtocol {
             switch action {
             case .viewDidLoad:
                 self?.fetchAllSeasonSong()
+            case .didSelectedSong(let indexPath):
+                self?.getSelectedSongDetailViewURL(indexPath: indexPath)
             }
         }
         .disposed(by: disposeBag)
@@ -65,5 +69,19 @@ final class HomeViewModel: ViewModelProtocol {
             }
         }
         .disposed(by: disposeBag)
+    }
+
+    private func getSelectedSongDetailViewURL(indexPath: IndexPath) {
+        let season = Season.allCases[indexPath.section]
+        let song: Song?
+        switch season {
+        case .spring: song = state.springSong.value[indexPath.item]
+        case .summer: song = state.summerSong.value[indexPath.item]
+        case .autumn: song = state.autumnSong.value[indexPath.item]
+        case .winter: song = state.winterSong.value[indexPath.item]
+        }
+        guard let song else { return }
+        guard let urlString = song.detailViewURL, let url = URL(string: urlString) else { return }
+        state.selectedSong.accept(url)
     }
 }

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/VIewModel/SearchResultViewModel.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/VIewModel/SearchResultViewModel.swift
@@ -12,11 +12,13 @@ import RxRelay
 final class SearchResultViewModel: ViewModelProtocol {
     enum Action {
         case didQueryChanged(String)
+        case didSelectCell(Int)
     }
 
     struct State {
         let searchKeyword = BehaviorRelay<String>(value: "")
         let show = BehaviorRelay<[Show]>(value: [])
+        let selectedShowURL = PublishRelay<URL>()
     }
 
     // MARK: - Properties
@@ -37,10 +39,16 @@ final class SearchResultViewModel: ViewModelProtocol {
 
     func bindActions() {
         action.bind { [weak self] action in
+            guard let self else { return }
             switch action {
             case .didQueryChanged(let query):
-                self?.setSearchKeyword(for: query)
-                self?.fetchShow(by: query)
+                setSearchKeyword(for: query)
+                fetchShow(by: query)
+            case .didSelectCell(let index):
+                let selectedShow = state.show.value[index]
+                guard let urlString = selectedShow.detailViewURL else { return } // TODO: Alert
+                guard let url = URL(string: urlString) else { return }
+                state.selectedShowURL.accept(url)
             }
         }
         .disposed(by: disposeBag)
@@ -53,7 +61,8 @@ final class SearchResultViewModel: ViewModelProtocol {
     private func fetchShow(by query: String) {
         fetchShowUseCase.execute(searchQuery: query)
             .subscribe { [weak self] shows in
-                self?.state.show.accept(shows)
+                guard let self else { return }
+                state.show.accept(shows)
             }
             .disposed(by: disposeBag)
     }

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/VIewModel/SearchResultViewModel.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/VIewModel/SearchResultViewModel.swift
@@ -19,6 +19,7 @@ final class SearchResultViewModel: ViewModelProtocol {
         let searchKeyword = BehaviorRelay<String>(value: "")
         let show = BehaviorRelay<[Show]>(value: [])
         let selectedShowURL = PublishRelay<URL>()
+        let noDetailView = PublishRelay<Void>()
     }
 
     // MARK: - Properties
@@ -45,10 +46,7 @@ final class SearchResultViewModel: ViewModelProtocol {
                 setSearchKeyword(for: query)
                 fetchShow(by: query)
             case .didSelectCell(let index):
-                let selectedShow = state.show.value[index]
-                guard let urlString = selectedShow.detailViewURL else { return } // TODO: Alert
-                guard let url = URL(string: urlString) else { return }
-                state.selectedShowURL.accept(url)
+                setSelectedShowURL(for: index)
             }
         }
         .disposed(by: disposeBag)
@@ -65,5 +63,15 @@ final class SearchResultViewModel: ViewModelProtocol {
                 state.show.accept(shows)
             }
             .disposed(by: disposeBag)
+    }
+
+    private func setSelectedShowURL(for index: Int) {
+        let selectedShow = state.show.value[index]
+        guard let urlString = selectedShow.detailViewURL else {
+            state.noDetailView.accept(())
+            return
+        }
+        guard let url = URL(string: urlString) else { return }
+        state.selectedShowURL.accept(url)
     }
 }

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/SearchResultView.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/SearchResultView.swift
@@ -93,7 +93,7 @@ final class SearchResultView: UIView {
                 ) as! ShowCell
 
                 let kind = show.kind == .movie ? "Movie" : "Podcast"
-                cell.updateCell(with: show.title, kind, show.artworkImageURL, backgroundColor: show.color)
+                cell.updateCell(with: show.title, kind, show.artworkImageURL, show.color)
 
                 return cell
             })

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/SearchResultView.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/SearchResultView.swift
@@ -15,6 +15,7 @@ final class SearchResultView: UIView {
 
     let headerTitle = BehaviorRelay<String>(value: "")
     let didTapHeader = PublishRelay<Void>()
+    let didSelectedCell = PublishRelay<Int>()
     private let disposeBag = DisposeBag()
     private var dataSource: UICollectionViewDiffableDataSource<SearchResultSection, Show>?
 
@@ -40,6 +41,7 @@ final class SearchResultView: UIView {
         setStyle()
         setHierarchy()
         setConstraints()
+        bind()
         setDataSource()
     }
 
@@ -67,6 +69,16 @@ final class SearchResultView: UIView {
         collectionView.snp.makeConstraints {
             $0.directionalEdges.equalToSuperview()
         }
+    }
+
+    // MARK: - Bind
+
+    private func bind() {
+        collectionView.rx.itemSelected
+            .subscribe { [weak self] indexPath in
+                self?.didSelectedCell.accept(indexPath.item)
+            }
+            .disposed(by: disposeBag)
     }
 
     // MARK: - DataSource Helper

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/Subview/ShowCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/Subview/ShowCell.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 import Then
 import RxSwift
+import RxCocoa
 
 final class ShowCell: UICollectionViewCell {
 
@@ -111,8 +112,12 @@ final class ShowCell: UICollectionViewCell {
             artworkImageView.image = nil
             return
         }
-        imageLoadTask = Task {
-            artworkImageView.image = await ImageLoader.shared.loadImage(from: url)
-        }
+        ImageLoader.shared.loadImage(from: url)
+            .asObservable()
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, image in
+                owner.artworkImageView.image = image
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/Subview/ShowCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/Subview/ShowCell.swift
@@ -90,19 +90,29 @@ final class ShowCell: UICollectionViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         imageLoadTask?.cancel()
-        updateCell(with: nil, nil, nil, backgroundColor: .clear)
+        updateCell(with: nil, nil, nil, .clear)
         disposeBag = DisposeBag()
     }
 
-    func updateCell(with title: String?, _ showKind: String?, _ artworkImageURL: String?, backgroundColor: UIColor) {
+    func updateCell(
+        with title: String?,
+        _ showKind: String?,
+        _ artworkImageURL: String?,
+        _ backgroundColor: UIColor
+    ) {
         showKindLabel.text = showKind
         titleLabel.text = title
         contentView.backgroundColor = backgroundColor
+        updateImageView(for: artworkImageURL)
+    }
 
-        guard let artworkImageURL else { return }
-        // TODO: Rx 사용
+    private func updateImageView(for url: String?) {
+        guard let url else {
+            artworkImageView.image = nil
+            return
+        }
         imageLoadTask = Task {
-            artworkImageView.image = await ImageLoader.shared.loadImage(from: artworkImageURL)
+            artworkImageView.image = await ImageLoader.shared.loadImage(from: url)
         }
     }
 }

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/Subview/ShowCell.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/View/Subview/ShowCell.swift
@@ -15,7 +15,6 @@ final class ShowCell: UICollectionViewCell {
 
     // MARK: - Properties
 
-    private var imageLoadTask: Task<Void, Never>?
     private var disposeBag = DisposeBag()
 
     // MARK: - UI Components
@@ -90,7 +89,6 @@ final class ShowCell: UICollectionViewCell {
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        imageLoadTask?.cancel()
         updateCell(with: nil, nil, nil, .clear)
         disposeBag = DisposeBag()
     }
@@ -113,7 +111,6 @@ final class ShowCell: UICollectionViewCell {
             return
         }
         ImageLoader.shared.loadImage(from: url)
-            .asObservable()
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, image in
                 owner.artworkImageView.image = image

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/ViewController/SearchResultViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/ViewController/SearchResultViewController.swift
@@ -46,6 +46,13 @@ final class SearchResultViewController: UIViewController {
     // MARK: - Bind
 
     private func bind() {
+        searchResultView.didSelectedCell
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, index in
+                owner.viewModel.action.accept(.didSelectCell(index))
+            }
+            .disposed(by: disposeBag)
+
         viewModel.state.searchKeyword
             .bind(with: self) { owner, keyword in
                 owner.searchResultView.headerTitle.accept(keyword)
@@ -57,6 +64,13 @@ final class SearchResultViewController: UIViewController {
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, shows in
                 owner.searchResultView.updateSnapshot(with: shows, toSection: .show)
+            }
+            .disposed(by: disposeBag)
+
+        viewModel.state.selectedShowURL
+            .asDriver(onErrorDriveWith: .empty())
+            .drive(with: self) { owner, url in
+                owner.present(DetailViewController(url: url), animated: true)
             }
             .disposed(by: disposeBag)
 

--- a/AppStoreClone/AppStoreClone/Presentation/SearchResult/ViewController/SearchResultViewController.swift
+++ b/AppStoreClone/AppStoreClone/Presentation/SearchResult/ViewController/SearchResultViewController.swift
@@ -70,7 +70,9 @@ final class SearchResultViewController: UIViewController {
         viewModel.state.selectedShowURL
             .asDriver(onErrorDriveWith: .empty())
             .drive(with: self) { owner, url in
-                owner.present(DetailViewController(url: url), animated: true)
+                let viewModel = DetailViewModel(webViewURL: url)
+                let viewController = DetailViewController(viewModel: viewModel)
+                owner.present(viewController, animated: true)
             }
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 💭 작업 내용
- 상세화면 구현: 영화, 팟캐스트는 collectionViewUrl, 노래는 trackViewUrl 전달하여 웹뷰 Present (Url이 없는 경우에는 Alert 제공)
- 이미지 캐싱: NSCache 사용
- 이미지 로드 리팩토링: 기존의 async/await에서 Rx를 사용하도록 하여 일관성 유지

## 🌤️ PR POINT
- 이미지 캐싱에서 캐시 이미지를 확인 후 가져오고, 추가하는 위치가 적절한지 검토 부탁드립니다.

## 📸 스크린샷
|    실행 기기    |   스크린샷(또는 GIF)   |
| :-------------: | :----------: |
| iPhone 13 mini - 상세화면 | <img src = "https://github.com/user-attachments/assets/819b54af-0ae9-4325-b018-7b5f661d7f33" width ="250"> |


## 🌈 관련 이슈
- Resolved: #14 #8

